### PR TITLE
fix:Publication date not visible by default

### DIFF
--- a/src/blocks/Listing/schema.js
+++ b/src/blocks/Listing/schema.js
@@ -124,6 +124,7 @@ export const setCardModelSchema = (args) => {
     hasDate: {
       title: 'Publication date',
       type: 'boolean',
+      default: false,
     },
     hasDescription: {
       title: 'Description',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/44702393/233421402-e726c032-b2be-4c62-9bb1-11e837aa86b4.png)

When publication date is unchecked by default, the card should not show the date