### PR TITLE
fix: TeaserGrid use the teaser template from this addon #251893

### DIFF
--- a/src/blocks/Teaser/index.js
+++ b/src/blocks/Teaser/index.js
@@ -32,12 +32,11 @@ export default (config) => {
   // Teaser Grid
   if (config.blocks.blocksConfig.teaserGrid) {
     config.blocks.blocksConfig.teaserGrid.title = 'Teaser (Cards)';
-    // console.log(config.blocks.blocksConfig.teaserGrid, 'teaser grid config');
   }
 
   if (config.blocks.blocksConfig.__grid && config.blocks.blocksConfig.teaser) {
     //because grid uses teaser from blocksConfig.__grid.blocksConfig.teaser
-    // and we need that teaser overriden as well
+    //and we need that teaser overriden as well
     config.blocks.blocksConfig.__grid.blocksConfig.teaser =
       config.blocks.blocksConfig.teaser;
   }

--- a/src/blocks/Teaser/index.js
+++ b/src/blocks/Teaser/index.js
@@ -32,6 +32,14 @@ export default (config) => {
   // Teaser Grid
   if (config.blocks.blocksConfig.teaserGrid) {
     config.blocks.blocksConfig.teaserGrid.title = 'Teaser (Cards)';
+    // console.log(config.blocks.blocksConfig.teaserGrid, 'teaser grid config');
+  }
+
+  if (config.blocks.blocksConfig.__grid && config.blocks.blocksConfig.teaser) {
+    //because grid uses teaser from blocksConfig.__grid.blocksConfig.teaser
+    // and we need that teaser overriden as well
+    config.blocks.blocksConfig.__grid.blocksConfig.teaser =
+      config.blocks.blocksConfig.teaser;
   }
 
   return config;


### PR DESCRIPTION
Grid uses teaser from blocksConfig.__grid.blocksConfig.teaser and not blocksConfig.teaser
Since we override the teaser in blocksConfig, the one in blocksConfig.__grid.blocksConfig.teaser is not changed.
This ensures the Template for Teaser is coming from volto-listing-block customization and not kitconcept/volto-blocks-grid