### PR TITLE
change(perf): lazy load item images and set width and height on image

### DIFF
--- a/src/blocks/Item/Item.jsx
+++ b/src/blocks/Item/Item.jsx
@@ -1,7 +1,25 @@
 import cx from 'classnames';
 import { Item as UiItem, Icon } from 'semantic-ui-react';
 import { getFieldURL } from '@eeacms/volto-listing-block/helpers';
+import config from '@plone/volto/registry';
 
+const ItemImage = ({ image, imageSize, verticalAlign }) => {
+  const imageURL = getFieldURL(image);
+  if (!imageURL) return null;
+  const imageSizes = config.blocks.blocksConfig.item.imageSizes;
+  const size = imageSizes[imageSize];
+
+  return (
+    <img
+      src={`${imageURL}/@@images/image/${imageSize}`}
+      className={cx('ui', imageSize, verticalAlign, 'aligned')}
+      alt=""
+      width={size.width}
+      height={size.height}
+      loading="lazy"
+    />
+  );
+};
 function Item({
   assetType,
   children,
@@ -17,15 +35,14 @@ function Item({
   mode = 'view',
   ...props
 }) {
-  const image = getFieldURL(props.image);
   return (
     <UiItem.Group unstackable className="row">
       <UiItem className={cx(theme)}>
-        {assetType === 'image' && image && (
-          <UiItem.Image
-            src={`${image}/@@images/image/${imageSize}`}
-            className={cx('ui', imageSize, verticalAlign, 'aligned')}
-            role="presentation"
+        {assetType === 'image' && (
+          <ItemImage
+            image={props.image}
+            imageSize={imageSize}
+            verticalAlign={verticalAlign}
           />
         )}
         {assetType === 'icon' && icon && (

--- a/src/blocks/Item/index.js
+++ b/src/blocks/Item/index.js
@@ -15,6 +15,13 @@ const applyConfig = (config) => {
     restricted: false,
     mostUsed: false,
     sidebarTab: 1,
+    imageSizes: {
+      tiny: { width: 24, height: 24 },
+      small: { width: 48, height: 48 },
+      medium: { width: 64, height: 64 },
+      big: { width: 80, height: 80 },
+      preview: { width: 400, height: 400 },
+    },
     security: {
       addPermission: [],
       view: [],


### PR DESCRIPTION
- this way we improve the score for Lighthouse rule that asks to Set an
  explicit width and height on image elements to reduce layout shifts and
  improve CLS. These image sizes are configurable from the config section
  with the key imageSizes